### PR TITLE
Fix/issue 73

### DIFF
--- a/src/radical/analytics/session.py
+++ b/src/radical/analytics/session.py
@@ -894,7 +894,20 @@ class Session(object):
                     ranges  = consumer_entity.ranges(event=consumer_events)
                     cons_id = consumer_entity.uid
 
-                    consumer_resources[cons_id] = consumer_entity.description.get(resource)
+                    consumer_nodes = consumer_entity.cfg.get('slots').get('nodes')
+                    resources_acquired = 0
+                    if resource == 'cores':
+                        for node in consumer_nodes:
+                            for cores_map in node[2]:
+                                resources_acquired += len(cores_map)
+                    elif resource == 'gpu':
+                        for node in consumer_nodes:
+                            for gpu_map in node[3]:
+                                resources_acquired += len(gpu_map)
+                    else:
+                        raise ValueError('Utilization for resource not supported')
+                    
+                    consumer_resources[cons_id] = resources_acquired
 
                     # Update consumer_ranges if there is at least one range
                     consumer_ranges.update({cons_id: ranges}) if len(ranges) != 0 else None

--- a/src/radical/analytics/session.py
+++ b/src/radical/analytics/session.py
@@ -900,7 +900,7 @@ class Session(object):
                         for node in consumer_nodes:
                             for cores_map in node[2]:
                                 resources_acquired += len(cores_map)
-                    elif resource == 'gpu':
+                    elif resource == 'gpus':
                         for node in consumer_nodes:
                             for gpu_map in node[3]:
                                 resources_acquired += len(gpu_map)


### PR DESCRIPTION
This branch fixes the utilization method. For every consumer entity it gets the resource mapping and counts the resources that consumer consumed.

In addition, I added a check whether the resource is `cores` or `gpus`. An error is raised when we try to find the utilization of a resource that does not exist in the mapping.