### PR TITLE
matplotlib 3.0.1+ requirement because of bugs e.g. failed to import g…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup_args = {
                                  '*.md', 'VERSION', 'SDIST', sdist_name]},
   # 'setup_requires'     : ['pytest-runner'],
     'install_requires'   : ['radical.utils>=1.0',
-                            'matplotlib<=3.0',
+                            'matplotlib>=3.1.2',
                             'psutil',
                             'pandas',
                             'numpy',


### PR DESCRIPTION
…et_backend, 3.1.2 latest release as of Dec 2019.