### PR TITLE
update

### DIFF
--- a/src/radical/analytics/entity.py
+++ b/src/radical/analytics/entity.py
@@ -329,10 +329,16 @@ class Entity(object):
     #
     def _match_event(self, needle, hay):
 
-        for key in range(ru.PROF_KEY_MAX):
+        for key in range(ru.PROF_KEY_MAX - 2):
             if needle[key] is not None:
                 if needle[key] != hay[key]:
                     return False
+
+        key = ru.PROF_KEY_MAX - 2
+        if needle[key] is not None:
+            if needle[key] not in hay[key]:
+                return False
+
         return True
 
 

--- a/src/radical/analytics/session.py
+++ b/src/radical/analytics/session.py
@@ -112,7 +112,7 @@ class Session(object):
         elif stype == 'radical.entk':
 
             try:
-                import radical.etk.utils as reu
+                import radical.entk.utils as reu
             except:
                 raise RuntimeError('radical.analytics requires the '
                                    'radical.entk module to analyze this '


### PR DESCRIPTION
This fixes #116 - please confirm.  I changes the `msg` check for event matching to match partial messages, which, combined with a resource spec update, allows us to cleaner separate `cmd` events.