### PR TITLE
Fix/concurrency

### DIFF
--- a/bin/rp_inspect/plot_conc.py
+++ b/bin/rp_inspect/plot_conc.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     for metric in data:
         x = [e[0] for e in data[metric]]
         y = [e[1] for e in data[metric]]
-        plt.plot(x, y, color=colors[metric], label=metric)
+        plt.step(x, y, color=colors[metric], label=metric, where='post')
 
     ax.legend(list(data.keys()), ncol=3, loc='upper center',
                                  bbox_to_anchor=(0.5,1.11))

--- a/src/radical/analytics/session.py
+++ b/src/radical/analytics/session.py
@@ -807,10 +807,6 @@ class Session(object):
         for uid,e in list(self._entities.items()):
             ranges += e.ranges(state, event, time)
 
-        print()
-        import pprint
-        pprint.pprint(ranges)
-
         if not ranges:
             return []
 
@@ -865,9 +861,6 @@ class Session(object):
             # append last time stamp if it is not appended, yet
             if ret[-1] != [t, val]:
                 ret.append([t, val])
-
-        print()
-        pprint.pprint(ret)
 
         return ret
 

--- a/src/radical/analytics/session.py
+++ b/src/radical/analytics/session.py
@@ -800,52 +800,74 @@ class Session(object):
                                         rp.AGENT_STAGING_OUTPUT_PENDING])
         '''
 
+        INC =  1  # increase concurrency
+        DEC = -1  # decrease concurrency
+
         ranges = list()
         for uid,e in list(self._entities.items()):
             ranges += e.ranges(state, event, time)
 
+        print()
+        import pprint
+        pprint.pprint(ranges)
+
         if not ranges:
-            # nothing to do
             return []
 
-
-        ret   = list()
         times = list()
-        if sampling:
-            # get min and max of ranges, and add create timestamps at regular
-            # intervals
-            r_min = ranges[0][0]
-            r_max = ranges[0][1]
-            for r in ranges:
-                r_min = min(r_min, r[0])
-                r_max = max(r_max, r[1])
+        # get all start and end times for all ranges.  The start of a range will
+        # increase concurrency by one at that time stamp, and the end will
+        # decrease it by one again.
+        for r in ranges:
+            times.append([r[0], INC])
+            times.append([r[1], DEC])
 
-            t = r_min
-            while t < r_max:
-                times.append(t)
-                t += sampling
-            times.append(t)
+        # sort those times
+        times.sort()
+
+        # get the overall concurrency data
+        conc = 0
+        data = list()  # [[time, concurrency], ...]
+        for time, val in times:
+            conc += val
+            data.append([time, conc])
+
+        # collapse time stamps (use last value on same time stamps)
+        collapsed = list()
+        last      = data[0]
+        for time, val in data[1:]:
+            if time != last[0]:
+                collapsed.append(last)
+            last = [time, val]
+
+        # append last time
+        collapsed.append(last)
+
+        # make sure we start at zero (at time of first event)
+        collapsed.insert(0, [collapsed[0][0], 0])
+
+        if not sampling:
+            # return as is
+            ret = collapsed
 
         else:
-            # get all start and end times for all ranges, and use the resulting
-            # set as time sequence
-            for r in ranges:
-                times.append(r[0])
-                times.append(r[1])
-            times.sort()
+            # select data points according to sampling
+            # get min time, and create timestamps at regular intervals
+            t     = times[ 0][0]
+            last  = r_min
+            ret   = list()
+            idx   = 0
+            for time, val in collapsed:
+                while time >= t:
+                    ret.append(t, val)
+                    t += sampling
 
-        # we have the time sequence, now compute concurrency at those points
-        for t in times:
-            cnt = 0
-            for r in ranges:
-                if t >= r[0] and t <= r[1]:
-                    cnt += 1
+            # append last time stamp if it is not appended, yet
+            if ret[-1] != [t, val]:
+                ret.append([t, val])
 
-            if ret and [t,cnt] == ret[-1]:
-                # avoid repetition of values
-                continue
-
-            ret.append([t, cnt])
+        print()
+        pprint.pprint(ret)
 
         return ret
 


### PR DESCRIPTION
This PR fixes the concurrecy computation: it now starts at zero and ends at zero (previsouly, initial and final values were not included).  Also, the inspect plots now use the correct step plot.  And, last but not least, the concurrency computation code becam simpler (I think).