### PR TITLE
Duration distributions and theme

### DIFF
--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -8,17 +8,35 @@ API Reference
 Session
 -------
 .. autoclass:: radical.analytics.Session
-   :members: 
+   :members:
    :special-members: __init__
 
 Entity
 ------
 .. autoclass:: radical.analytics.Entity
-   :members: 
+   :members:
    :special-members: __init__
 
 Experiment
 ----------
 .. autoclass:: radical.analytics.Experiment
-   :members: 
+   :members:
    :special-members: __init__
+
+utils
+-----
+.. autofunction:: radical.analytics.get_plotsize
+
+.. autofunction:: radical.analytics.get_mplstyle
+
+.. autofunction:: radical.analytics.stack_transitions
+
+.. autofunction:: radical.analytics.get_pilot_series
+
+.. autofunction:: radical.analytics.get_plot_utilization
+
+.. autofunction:: radical.analytics.get_pilots_zeros
+
+.. autofunction:: radical.analytics.to_latex
+
+.. autofunction:: radical.analytics.tabulate_durations

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'nbsphinx',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'sphinx_rtd_theme'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -136,7 +137,8 @@ todo_include_todos = True
 # html_theme = 'alabaster'
 
 # RADICAL docs theme
-html_theme = "armstrong"
+# html_theme = "armstrong"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/duration.ipynb
+++ b/docs/source/duration.ipynb
@@ -5,14 +5,14 @@
    "id": "8d155872",
    "metadata": {},
    "source": [
-    "# Durations\n",
+    "# Duration\n",
     "\n",
     "\n",
     "In RA, ``duration`` is a general term to indicate a measure of the time spent by an instance of an entity (local analyses) or a set of instances of an entity (global analyses) between two timestamps. For example, staging, scheduling, pre-execute, execute time of one or more compute tasks; description, submission and execution time of one or more pipelines or stages; and runtime of one or more pilots.\n",
     "\n",
     "We show two sets of default durations for RADICAL-Pilot and how to define arbitrary durations, depending on the specifics of a given analysis. We then see how to plot the most common durations \n",
     "\n",
-    "## Prolog\n",
+    "## Prologue\n",
     "\n",
     "Load all the Python modules needed to profile and plot a RADICAL-EnsembleToolkit (EnTK) session."
    ]
@@ -72,7 +72,11 @@
    "id": "9015dbc7",
    "metadata": {},
    "source": [
-    "Usually, it is useful to record the stack used for the analysis. Note that the stack used for the analysis might be different from the stack used to crete the session to analyze. Usually, the two stack have to have the same major release number in order to be compatible."
+    "Usually, it is useful to record the stack used for the analysis. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> The stack used for the analysis might be different from the stack used to crete the session to analyze. Usually, the two stack have to have the same major release number in order to be compatible.\n",
+    "</div>"
    ]
   },
   {
@@ -149,7 +153,10 @@
     "\n",
     "RA enables the **arbitrary** definition of durations. What duration you need, depends on why you need a certain measure. For example, given an experiment to charaterize the performance of one of RP executors, it might be useful to measure the amount of time spent by each task in the Executor component. \n",
     "\n",
-    "Correctly defining that duration requires a detailed understanding of both `RP architecture <https://github.com/radical-cybertools/radical.pilot/wiki/Architecture>`_ and `event model <https://github.com/radical-cybertools/radical.pilot/blob/devel/docs/source/events.md>`_. \n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Warning:</b> Correctly defining a duration requires a <b>detailed</b> understanding of both <a href=\"https://github.com/radical-cybertools/radical.pilot/wiki/Architecture\">RP architecture</a> and <a href=\"https://github.com/radical-cybertools/radical.pilot/blob/devel/docs/source/events.md\">event model</a>. \n",
+    "</div>\n",
+    "\n",
     "\n",
     "Once we acquired that understanding, we can define our duration as the sum of the time spent by the task in the Executor component before and after the execution of the task's executable."
    ]
@@ -160,8 +167,8 @@
    "id": "90f0be8f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-23T09:04:31.832849Z",
-     "start_time": "2021-07-23T09:04:31.828711Z"
+     "end_time": "2021-07-23T10:34:59.234035Z",
+     "start_time": "2021-07-23T10:34:59.089601Z"
     }
    },
    "outputs": [],
@@ -239,7 +246,15 @@
     }
    },
    "source": [
-    "Create a ``ra.Session`` object for the session. We are not going to use EnTK-specific traces so we are going to load only the RP traces contained in the EnTK session. Thus, we pass the ``'radical.pilot'`` session type to ``ra.Session``. We already know we will want to derive information about pilot(s) and tasks. Thus, we save in memory a session objects filtered for those two identities. Note that this might be too expensive in some cases. We save the ouput of ``ra.Session`` in ``capt`` to avoid polluting the notebook."
+    "Create a ``ra.Session`` object for the session. We are not going to use EnTK-specific traces so we are going to load only the RP traces contained in the EnTK session. Thus, we pass the ``'radical.pilot'`` session type to ``ra.Session``.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Warning:</b> We already know we will want to derive information about pilot(s) and tasks. Thus, we save in memory a session objects filtered for those two identities. This might be too expensive with large sessions, depending on the amount of memory available.\n",
+    "</div>\n",
+    "    \n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> We save the ouput of ``ra.Session`` in ``capt`` to avoid polluting the notebook. \n",
+    "</div>"
    ]
   },
   {
@@ -270,7 +285,7 @@
    "source": [
     "As seen above, durations measure the time spent by an instance of an entity (local analyses) or a set of instances of an entity (global analyses) between two timestamps. For example, staging, scheduling, pre-execute, execute time of one or more compute tasks; description, submission and execution time of one or more pipelines or stages; and runtime of one or more pilots.\n",
     "\n",
-    "We starts with a global analysis to measure for how long all the pilots of our run have been active. Looking at the `event model <https://github.com/radical-cybertools/radical.pilot/blob/devel/docs/source/events.md#bootstrap_0sh>`__ of the entity of type ``pilot`` and to ``rp.utils.PILOT_DURATIONS_DEBUG``, we know that a pilot is active between the event ``TMGR_STAGING_OUTPUT`` and one of the final events ``DONE``, ``CANCELED`` or ``FAILED``. We also know that we have a default duration with those events: ``p_agent_runtime``.\n",
+    "We starts with a global analysis to measure for how long all the pilots of our run have been active. Looking at the __[event model](https://github.com/radical-cybertools/radical.pilot/blob/devel/docs/source/events.md#bootstrap_0sh)__ of the entity of type ``pilot`` and to ``rp.utils.PILOT_DURATIONS_DEBUG``, we know that a pilot is active between the event ``TMGR_STAGING_OUTPUT`` and one of the final events ``DONE``, ``CANCELED`` or ``FAILED``. We also know that we have a default duration with those events: ``p_agent_runtime``.\n",
     "\n",
     "To measure that duration, first, we filter the session object so to keep only the entities of type Pilot; and, second, we get the **cumulative** amount of time for which all the pilot were active:"
    ]
@@ -296,7 +311,9 @@
    "id": "205be4db",
    "metadata": {},
    "source": [
-    "**Note**: This works for a set of pilots, including the case in which we have a single pilot. If we have a single pilot, the cumulative active time of all the pilots is equal to the active time of the only available pilot.\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> This works for a set of pilots, including the case in which we have a single pilot. If we have a single pilot, the cumulative active time of all the pilots is equal to the active time of the only available pilot.\n",
+    "</div>\n",
     "\n",
     "If we have more than one pilot and we want to measure the active time of one of them, then we need to perform a local analysis. A rapid way to get a list of all the pilot entities in the session and, for example, see their unique identifiers (uid) is:"
    ]
@@ -569,8 +586,11 @@
     "\n",
     "fig.text(  0.05,  0.5 , 'Time (s)', va='center', rotation='vertical')\n",
     "fig.text(  0.5 , -0.2, 'Metric'  , ha='center')\n",
-    "fig.legend(['RADICAL Cybertools overhead (OVH)', 'Workflow time to completion (TTX)'], loc='upper center', \n",
-    "           bbox_to_anchor=(0.5, 1.5), ncol=1)"
+    "fig.legend(['RADICAL Cybertools overhead (OVH)', \n",
+    "            'Workflow time to completion (TTX)'], \n",
+    "           loc='upper center', \n",
+    "           bbox_to_anchor=(0.5, 1.5), \n",
+    "           ncol=1)"
    ]
   },
   {
@@ -608,7 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81f6cdc0",
+   "id": "56c6d284",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-07-23T09:04:41.599457Z",
@@ -634,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b788c9eb",
+   "id": "1e23255a",
    "metadata": {},
    "source": [
     "We can now plot the distribution of task runtime as a boxplot for each session:"
@@ -643,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "667b8106",
+   "id": "88e8771f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-07-23T09:04:41.812200Z",
@@ -666,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "187c9c0d",
+   "id": "c6db9a20",
    "metadata": {},
    "source": [
     "We can do the same for the arbitrary defined durations `t_executor_before` and `t_executor_after`"
@@ -675,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37283819",
+   "id": "b97c0035",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-07-23T09:04:42.631310Z",

--- a/docs/source/durations.ipynb
+++ b/docs/source/durations.ipynb
@@ -23,14 +23,15 @@
    "id": "2a4e3b2f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:17.388663Z",
-     "start_time": "2021-07-20T12:51:16.720096Z"
+     "end_time": "2021-07-23T09:04:30.669771Z",
+     "start_time": "2021-07-23T09:04:20.249205Z"
     }
    },
    "outputs": [],
    "source": [
     "import tarfile\n",
     "\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
@@ -57,8 +58,8 @@
    "id": "6317bea7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:17.399263Z",
-     "start_time": "2021-07-20T12:51:17.392253Z"
+     "end_time": "2021-07-23T09:04:30.678555Z",
+     "start_time": "2021-07-23T09:04:30.672362Z"
     }
    },
    "outputs": [],
@@ -80,8 +81,8 @@
    "id": "12df0932",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:18.340065Z",
-     "start_time": "2021-07-20T12:51:17.401363Z"
+     "end_time": "2021-07-23T09:04:31.789958Z",
+     "start_time": "2021-07-23T09:04:30.679928Z"
     }
    },
    "outputs": [],
@@ -105,8 +106,8 @@
    "id": "7da51bd0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:18.370139Z",
-     "start_time": "2021-07-20T12:51:18.344990Z"
+     "end_time": "2021-07-23T09:04:31.813150Z",
+     "start_time": "2021-07-23T09:04:31.793516Z"
     }
    },
    "outputs": [],
@@ -120,8 +121,8 @@
    "id": "19bd49d3",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:18.385228Z",
-     "start_time": "2021-07-20T12:51:18.372462Z"
+     "end_time": "2021-07-23T09:04:31.826216Z",
+     "start_time": "2021-07-23T09:04:31.815625Z"
     }
    },
    "outputs": [],
@@ -159,8 +160,8 @@
    "id": "90f0be8f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:18.392202Z",
-     "start_time": "2021-07-20T12:51:18.387347Z"
+     "end_time": "2021-07-23T09:04:31.832849Z",
+     "start_time": "2021-07-23T09:04:31.828711Z"
     }
    },
    "outputs": [],
@@ -169,9 +170,7 @@
     "                     {ru.EVENT: 'task_exec_start', ru.STATE: None               } ]\n",
     "\n",
     "t_executor_after  = [{ru.EVENT: 'task_exec_stop' , ru.STATE: None               }, \n",
-    "                     {ru.EVENT: 'task_stop'      , ru.STATE: None               } ]\n",
-    "\n",
-    "t_executor = t_executor_before + t_executor_after"
+    "                     {ru.EVENT: 'task_stop'      , ru.STATE: None               } ]"
    ]
   },
   {
@@ -194,8 +193,8 @@
    "id": "446da70d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:18.398012Z",
-     "start_time": "2021-07-20T12:51:18.394298Z"
+     "end_time": "2021-07-23T09:04:31.838514Z",
+     "start_time": "2021-07-23T09:04:31.835349Z"
     }
    },
    "outputs": [],
@@ -218,8 +217,8 @@
    "id": "529d0626",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:18.755102Z",
-     "start_time": "2021-07-20T12:51:18.400267Z"
+     "end_time": "2021-07-23T09:04:32.144211Z",
+     "start_time": "2021-07-23T09:04:31.841017Z"
     }
    },
    "outputs": [],
@@ -249,8 +248,8 @@
    "id": "87e37f4a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:21.584103Z",
-     "start_time": "2021-07-20T12:51:18.758008Z"
+     "end_time": "2021-07-23T09:04:34.960329Z",
+     "start_time": "2021-07-23T09:04:32.145914Z"
     }
    },
    "outputs": [],
@@ -282,8 +281,8 @@
    "id": "44da6554",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:21.595309Z",
-     "start_time": "2021-07-20T12:51:21.588596Z"
+     "end_time": "2021-07-23T09:04:34.970886Z",
+     "start_time": "2021-07-23T09:04:34.964596Z"
     }
    },
    "outputs": [],
@@ -308,8 +307,8 @@
    "id": "a8f871db",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:21.602569Z",
-     "start_time": "2021-07-20T12:51:21.597681Z"
+     "end_time": "2021-07-23T09:04:34.978716Z",
+     "start_time": "2021-07-23T09:04:34.973356Z"
     }
    },
    "outputs": [],
@@ -332,8 +331,8 @@
    "id": "84cd3836",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:21.614277Z",
-     "start_time": "2021-07-20T12:51:21.605696Z"
+     "end_time": "2021-07-23T09:04:34.989020Z",
+     "start_time": "2021-07-23T09:04:34.981174Z"
     }
    },
    "outputs": [],
@@ -359,8 +358,8 @@
    "id": "3048eda7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:21.624946Z",
-     "start_time": "2021-07-20T12:51:21.616798Z"
+     "end_time": "2021-07-23T09:04:34.999135Z",
+     "start_time": "2021-07-23T09:04:34.991171Z"
     }
    },
    "outputs": [],
@@ -387,8 +386,8 @@
    "id": "6880ec8d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:21.632123Z",
-     "start_time": "2021-07-20T12:51:21.627430Z"
+     "end_time": "2021-07-23T09:04:35.005914Z",
+     "start_time": "2021-07-23T09:04:35.001836Z"
     }
    },
    "outputs": [],
@@ -415,8 +414,8 @@
    "id": "6d4c5d8b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:22.502037Z",
-     "start_time": "2021-07-20T12:51:21.634846Z"
+     "end_time": "2021-07-23T09:04:35.768699Z",
+     "start_time": "2021-07-23T09:04:35.008274Z"
     }
    },
    "outputs": [],
@@ -442,8 +441,8 @@
    "id": "a964c769",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:27.436593Z",
-     "start_time": "2021-07-20T12:51:22.504337Z"
+     "end_time": "2021-07-23T09:04:40.724915Z",
+     "start_time": "2021-07-23T09:04:35.770737Z"
     }
    },
    "outputs": [],
@@ -472,8 +471,8 @@
    "id": "6f4095ee",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:27.444022Z",
-     "start_time": "2021-07-20T12:51:27.438303Z"
+     "end_time": "2021-07-23T09:04:40.733629Z",
+     "start_time": "2021-07-23T09:04:40.727159Z"
     }
    },
    "outputs": [],
@@ -506,8 +505,8 @@
    "id": "cb0d671a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:27.460784Z",
-     "start_time": "2021-07-20T12:51:27.446389Z"
+     "end_time": "2021-07-23T09:04:40.752696Z",
+     "start_time": "2021-07-23T09:04:40.736040Z"
     }
    },
    "outputs": [],
@@ -538,8 +537,8 @@
    "id": "5506655c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-07-20T12:51:28.288549Z",
-     "start_time": "2021-07-20T12:51:27.462768Z"
+     "end_time": "2021-07-23T09:04:41.564578Z",
+     "start_time": "2021-07-23T09:04:40.755090Z"
     }
    },
    "outputs": [],
@@ -558,7 +557,7 @@
     "    else:\n",
     "        ax = axarr\n",
     "    \n",
-    "    ax.title.set_text('%s/%s Tasks/Nodes' % (ss[sid]['ntask'], int(ss[sid]['nnodes'])))\n",
+    "    ax.title.set_text('%s tasks; %s nodes' % (ss[sid]['ntask'], int(ss[sid]['nnodes'])))\n",
     "\n",
     "    ax.bar(x = 'OVH', height = ss[sid]['ovh'])\n",
     "    ax.bar(x = 'TTX', height = ss[sid]['ttx'])\n",
@@ -599,9 +598,111 @@
    "source": [
     "## Distribution of Durations\n",
     "\n",
-    "We want to calculate the statistical distribution of arbitrary durations. Variance and outliers characterize the runtime behavior of both tasks and RADICAL-Cybertools.\n",
+    "We want to calculate the statistical distribution of default and arbitrary durations. Variance and outliers characterize the runtime behavior of both tasks and RADICAL-Cybertools.\n",
     "\n",
-    "To be done."
+    "Global durations like TTX and OVH are aggregate across all entities: TTX aggregates the duration of each task while OVH that of all the pilot components active hen no tasks are executed. For a distribution, we need instead the measure for each entity and component. For example, to calculate the distribution of task execution time, we have to measure the execution time of each task.\n",
+    "\n",
+    "We use RA to cycle through all the task entities and then the `get` and `duration` methods to return the wanted duration for each task. We use both the default duration for task runtime and the two arbitary durations we defined above for the time taken by RP executor to manage the execution of the task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81f6cdc0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-07-23T09:04:41.599457Z",
+     "start_time": "2021-07-23T09:04:41.567234Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "t_duration = {}\n",
+    "events = {'tx': rp.utils.TASK_DURATIONS_DEBUG['u_agent_lm_execute'], \n",
+    "          't_executor_before': t_executor_before, \n",
+    "          't_executor_after': t_executor_after}\n",
+    "\n",
+    "for sid in sids:\n",
+    "    t_duration[sid] = {}\n",
+    "    for name, event in events.items():\n",
+    "        t_duration[sid].update({name: []})    \n",
+    "        for tid in ss[sid]['t'].list('uid'):\n",
+    "            task = ss[sid]['t'].get(etype='task', uid=tid)[0]\n",
+    "            duration = task.duration(event=event)\n",
+    "            t_duration[sid][name].append(duration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b788c9eb",
+   "metadata": {},
+   "source": [
+    "We can now plot the distribution of task runtime as a boxplot for each session:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "667b8106",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-07-23T09:04:41.812200Z",
+     "start_time": "2021-07-23T09:04:41.602324Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fwidth, fhight = ra.get_plotsize(212)\n",
+    "fig, ax = plt.subplots(figsize=(fwidth, fhight))\n",
+    "\n",
+    "data   = [t_duration[sid]['tx'] for sid in sids]\n",
+    "labels = ['%s;%s' % (ss[sid]['ntask'], int(ss[sid]['nnodes'])) for sid in sids]\n",
+    "\n",
+    "ax.boxplot(data, labels=labels, patch_artist=True)\n",
+    "\n",
+    "ax.set_xlabel('Task;Nodes')\n",
+    "ax.set_ylabel('Task Runtime (s)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "187c9c0d",
+   "metadata": {},
+   "source": [
+    "We can do the same for the arbitrary defined durations `t_executor_before` and `t_executor_after`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37283819",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-07-23T09:04:42.631310Z",
+     "start_time": "2021-07-23T09:04:41.814488Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fwidth, fhight = ra.get_plotsize(212, subplots=(2, 1))\n",
+    "fig, axarr = plt.subplots(2, 1, figsize=(fwidth, fhight))\n",
+    "plt.subplots_adjust(hspace=0.6)\n",
+    "\n",
+    "i = 0\n",
+    "for dname in ['t_executor_before', 't_executor_after']:\n",
+    "    ax = axarr[i]\n",
+    "\n",
+    "    data   = [t_duration[sid][dname] for sid in sids]\n",
+    "    labels = ['%s;%s' % (ss[sid]['ntask'], int(ss[sid]['nnodes'])) for sid in sids]\n",
+    "\n",
+    "    ax.boxplot(data, labels=labels, patch_artist=True)\n",
+    "\n",
+    "    ax.set_title('Distribution of duration: %s' % ra.to_latex(dname))\n",
+    "    ax.set_xlabel('Task;Nodes')\n",
+    "    ax.set_ylabel('Task Runtime (s)')\n",
+    "    \n",
+    "    i += 1\n",
+    "    "
    ]
   }
  ],

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,13 +30,9 @@ RA has supported the development and experimental analysis of most of the
 `papers published <http://radical.rutgers.edu/publications/>`_ by `RADICAL
 <http://radical.rutgers.edu/>`_ at Rutgers University.
 
-**Links**
+.. * repository:     https://github.com/radical-cybertools/radical.analytics
+.. * issues:         https://github.com/radical-cybertools/radical.analytics/issues
 
-* repository:     https://github.com/radical-cybertools/radical.analytics
-* issues:         https://github.com/radical-cybertools/radical.analytics/issues
-
-Content
--------
 
 .. toctree::
    :numbered:
@@ -45,7 +41,7 @@ Content
    introduction.rst
    installation.rst
    inspection.rst
-   durations.ipynb
+   duration.ipynb
    concurrency.rst
    utilization.ipynb
    plotting.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,16 @@
+*****************
 RADICAL-Analytics
-=================
+*****************
+
+.. image:: https://img.shields.io/pypi/v/radical_analytics.svg
+   :target: https://pypi.python.org/pypi/radical_analytics
+   :alt: Pypi Version
+.. image:: https://img.shields.io/pypi/l/radical_analytics.svg
+   :target: https://pypi.python.org/pypi/radical_analytics/
+   :alt: License
+.. image:: https://readthedocs.org/projects/radicalanalytics/badge/?version=latest
+   :target: http://radicalanalytics.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
 
 `RADICAL-Analytics <https://github.com/radical-cybertools/radical.analytics>`_
 (RA) is a library implemented in Python to support the analysis of traces
@@ -26,12 +37,12 @@ variables. RA also enables introspecting the behavior of RP or EnTK, measuring
 and characterizing percentage of resource utilization, information flow, and
 distribution patterns.
 
-RA has supported the development and experimental analysis of most of the
+RA supports the development and experimental analysis of the
 `papers published <http://radical.rutgers.edu/publications/>`_ by `RADICAL
 <http://radical.rutgers.edu/>`_ at Rutgers University.
 
-.. * repository:     https://github.com/radical-cybertools/radical.analytics
-.. * issues:         https://github.com/radical-cybertools/radical.analytics/issues
+* repository:     https://github.com/radical-cybertools/radical.analytics
+* issues:         https://github.com/radical-cybertools/radical.analytics/issues
 
 
 .. toctree::

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -9,3 +9,4 @@ ipykernel
 nbsphinx
 pandas
 matplotlib
+sphinx-rtd-theme

--- a/docs/source/utilization.ipynb
+++ b/docs/source/utilization.ipynb
@@ -71,7 +71,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Usually, it is useful to record the stack used for the analysis. Note that the stack used for the analysis might be different from the stack used to crete the session to analyze. Usually, the two stack have to have the same major release number in order to be compatible."
+    "Usually, it is useful to record the stack used for the analysis. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> The stack used for the analysis might be different from the stack used to crete the session to analyze. Usually, the two stack have to have the same major release number in order to be compatible.\n",
+    "</div>"
    ]
   },
   {
@@ -184,7 +188,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a ``ra.Session`` object for each session of the experiment. We are not going to use EnTK-specific traces so we are going to load only the RP traces contained in the EnTK sessions. Thus, we pass the ``'radical.pilot'`` session type to ``ra.Session``. We already know we will want to derive information about pilot(s) and tasks. Thus, we save in memory a session objects filtered for those two identities. Note that this might be too expensive in some cases. We save the ouput of ``ra.Session`` in ``capt`` to avoid polluting the notebook."
+    "Create a ``ra.Session`` object for the session. We are not going to use EnTK-specific traces so we are going to load only the RP traces contained in the EnTK session. Thus, we pass the ``'radical.pilot'`` session type to ``ra.Session``.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <b>Warning:</b> We already know we will want to derive information about pilot(s) and tasks. Thus, we save in memory a session objects filtered for those two identities. This might be too expensive with large sessions, depending on the amount of memory available.\n",
+    "</div>\n",
+    "    \n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> We save the ouput of ``ra.Session`` in ``capt`` to avoid polluting the notebook. \n",
+    "</div>"
    ]
   },
   {
@@ -260,6 +272,8 @@
    },
    "outputs": [],
    "source": [
+    "%%capture capt\n",
+    "\n",
     "exp = ra.Experiment(sessions, stype='radical.pilot')"
    ]
   },
@@ -466,7 +480,7 @@
     "\n",
     "### Metrics\n",
     "\n",
-    "The definition of metrics needs to be accompanied by the explicit definition of the event transitions represented by each metric. RP transitions are documented `here <https://github.com/radical-cybertools/radical.pilot/blob/devel/docs/source/events.md>`_ but default values will be made available at a later time."
+    "The definition of metrics needs to be accompanied by the explicit definition of the event transitions represented by each metric. RP transitions are documented __[here](https://github.com/radical-cybertools/radical.pilot/blob/devel/docs/source/events.md>)__ but default values will be made available at a later time."
    ]
   },
   {

--- a/src/radical/analytics/utils/plot.py
+++ b/src/radical/analytics/utils/plot.py
@@ -425,17 +425,17 @@ def get_plot_utilization(metrics, consumed, t_zero, sid):
 def to_latex(data):
     '''
     Transforms the input string(s) so that it can be used as latex compiled plot
-    label, title etc. Escapes special characters with `\\`.
+    label, title etc. Escapes special characters with `\\\\`.
 
     Parameters
     ----------
     data : list or str
-           an individual string or a list of strings to transform
+           An individual string or a list of strings to transform.
 
     Returns
     -------
     data : list of str
-           transformed data
+           Transformed data.
     '''
 
     if isinstance(data, list):
@@ -466,13 +466,13 @@ def tabulate_durations(durations):
     Parameters
     ----------
     durations : dict
-                This is a dict of lists of dicts/lists of dicts. It contains
+                Dict of lists of dicts/lists of dicts. It contains
                 details about states and events.
 
     Returns
     -------
     data : list
-           list of dicts, each dict containing 'Duration Name',
+           List of dicts, each dict containing 'Duration Name',
            'Start Timestamp' and 'Stop Timestamp'.
     '''
     table = []

--- a/src/radical/analytics/utils/plot.py
+++ b/src/radical/analytics/utils/plot.py
@@ -425,7 +425,7 @@ def get_plot_utilization(metrics, consumed, t_zero, sid):
 def to_latex(data):
     '''
     Transforms the input string(s) so that it can be used as latex compiled plot
-    label, title etc. Escapes special characters with `\\\\`.
+    label, title etc. Escapes special characters with a slash.
 
     Parameters
     ----------

--- a/src/radical/analytics/utils/plot.py
+++ b/src/radical/analytics/utils/plot.py
@@ -424,8 +424,8 @@ def get_plot_utilization(metrics, consumed, t_zero, sid):
 #
 def to_latex(data):
     '''
-    Transform the input string(s) so that it can be used as latex compiled plot
-    label, title etc.  This method escapes special characters with `\\`.
+    Transforms the input string(s) so that it can be used as latex compiled plot
+    label, title etc. Escapes special characters with `\\`.
 
     Parameters
     ----------
@@ -443,17 +443,23 @@ def to_latex(data):
 
     else:
         assert(isinstance(data, str)), type(data)
-        return data.replace('%', '\\%') \
-                   .replace('#', '\\#') \
-                   .replace('_', '\\_')
+        return data.replace('%',  '\\%') \
+                   .replace('#',  '\\#') \
+                   .replace('_',  '\\_') \
+                   .replace('$',  '\\$') \
+                   .replace('&',  '\\&') \
+                   .replace('~',  '\\~') \
+                   .replace('^',  '\\^') \
+                   .replace('{',  '\\{') \
+                   .replace('}',  '\\}')
 
 
 # ------------------------------------------------------------------------------
 #
 def tabulate_durations(durations):
     '''
-    Take a dict of durations as defined in rp.utils (e.g.,
-    rp.utils.PILOT_DURATIONS_DEBUG) and returns a list of durations with their
+    Takes a dict of durations as defined in rp.utils (e.g.,
+    `rp.utils.PILOT_DURATIONS_DEBUG`) and returns a list of durations with their
     start and stop timestamps. That list can be directly converted to a
     panda.df.
 


### PR DESCRIPTION
This add documentation and code to plot duration distributions. It also changes the theme to the default for reads the docs. It is similar to the one we were using but it is still maintained. The previous one (armstrong) has been unmaintained for 10 years and it was missing macros to create proper TOC in the left pane. If you like it, I would move all RCT to this theme.