### PR TITLE
get cores_per_node from rm_info

### DIFF
--- a/bin/rp_inspect/plot_util.py
+++ b/bin/rp_inspect/plot_util.py
@@ -128,9 +128,11 @@ if __name__ == '__main__':
     assert(len(pilots) == 1), len(pilots)
 
     sid     = session.uid
-    p_zero  = pilots[0].timestamps(event={ru.EVENT: 'bootstrap_0_start'})[0]
-    p_size  = pilots[0].description['cores']
-    n_nodes = int(p_size / pilots[0].cfg['cores_per_node'])
+    pilot   = pilots[0]
+    rm_info = pilot.cfg['resource_details']['rm_info']
+    p_zero  = pilot.timestamps(event={ru.EVENT: 'bootstrap_0_start'})[0]
+    p_size  = pilot.description['cores']
+    n_nodes = int(p_size / rm_info['cores_per_node'])
     n_tasks = len(session.get(etype='task'))
 
     legend = None

--- a/bin/rp_inspect/plot_util_2.py
+++ b/bin/rp_inspect/plot_util_2.py
@@ -105,10 +105,11 @@ def main():
     pilots = session.get(etype='pilot')
     assert(len(pilots) == 1), len(pilots)
 
-    pilot   = pilots[0]
     sid     = session.uid
-    p_size  = pilots[0].description['cores']
-    n_nodes = int(p_size / pilots[0].cfg['cores_per_node'])
+    pilot   = pilots[0]
+    rm_info = pilot.cfg['resource_details']['rm_info']
+    p_size  = pilot.description['cores']
+    n_nodes = int(p_size / rm_info['cores_per_node'])
     n_tasks = len(session.get(etype='task'))
 
     # Derive pilot and task timeseries of a session for each metric


### PR DESCRIPTION
This PR keeps up with changes in RP.  Specifically, the `cores_per_node` information is now correctly stored in the `resource_details` of the pilot config.